### PR TITLE
feat: image-pull duration + cache-hit metrics and image-bench tool

### DIFF
--- a/charts/arl-operator/files/dashboards/arl.json
+++ b/charts/arl-operator/files/dashboards/arl.json
@@ -1,614 +1,2130 @@
 {
-  "annotations": { "list": [] },
-  "description": "ARL Infra — Operator, Gateway, Pool & Sandbox monitoring",
-  "editable": true,
-  "graphTooltip": 1,
-  "links": [],
-  "panels": [
-    {
-      "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 0 },
-      "id": 100,
-      "title": "Overview",
-      "type": "row"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "orange", "value": 80 },
-            { "color": "red", "value": 100 }
-          ]},
-          "mappings": [],
-          "unit": "short"
-        }
-      },
-      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
-      "id": 1,
-      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum(arl_gateway_active_sessions)", "legendFormat": "Sessions" }],
-      "title": "Active Sessions",
-      "type": "stat"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "red", "value": null },
-            { "color": "orange", "value": 1 },
-            { "color": "green", "value": 3 }
-          ]},
-          "unit": "short"
-        }
-      },
-      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
-      "id": 2,
-      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum(arl_pool_utilization{status=\"ready\"})", "legendFormat": "Ready" }],
-      "title": "Pool Ready Pods",
-      "type": "stat"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "orange", "value": 5 },
-            { "color": "red", "value": 10 }
-          ]},
-          "unit": "short"
-        }
-      },
-      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
-      "id": 3,
-      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum(arl_pool_utilization{status=\"allocated\"})", "legendFormat": "Allocated" }],
-      "title": "Allocated Pods",
-      "type": "stat"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "orange", "value": 3 },
-            { "color": "red", "value": 10 }
-          ]},
-          "unit": "short"
-        }
-      },
-      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 1 },
-      "id": 4,
-      "options": { "colorMode": "value", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum(arl_warmpool_pending_pods)", "legendFormat": "Pending" }],
-      "title": "Pending Pods",
-      "type": "stat"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 5 },
-      "id": 5,
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum by (status) (arl_pool_utilization{pool=~\"$pool\"})", "legendFormat": "{{status}}", "interval": "15s" }
-      ],
-      "title": "Pool Utilization",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10, "stacking": { "mode": "normal" } } }
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 13 },
-      "id": 17,
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"], "sortBy": "Last *", "sortDesc": true } },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "topk(20, max_over_time(arl_pool_utilization{status=\"allocated\"}[1m]) > 0)", "legendFormat": "{{pool}}", "instant": false, "interval": "30s" }
-      ],
-      "title": "Top 20 Active Pools (allocated > 0)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 5 },
-      "id": 6,
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum by (controller, result) (rate(arl_reconcile_total[5m]))", "legendFormat": "{{controller}} / {{result}}" }
-      ],
-      "title": "Reconcile Rate",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 21 },
-      "id": 101,
-      "title": "Pod Lifecycle",
-      "type": "row"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 22 },
-      "id": 7,
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(arl_warmpool_pod_ready_seconds_bucket[5m])))", "legendFormat": "p50" },
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(arl_warmpool_pod_ready_seconds_bucket[5m])))", "legendFormat": "p95" },
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(arl_warmpool_pod_ready_seconds_bucket[5m])))", "legendFormat": "p99" }
-      ],
-      "title": "Pod Ready Duration (creation→ready)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 22 },
-      "id": 8,
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.50, sum by (container, le) (rate(arl_warmpool_container_start_seconds_bucket[5m])))", "legendFormat": "p50 {{container}}" },
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.95, sum by (container, le) (rate(arl_warmpool_container_start_seconds_bucket[5m])))", "legendFormat": "p95 {{container}}" }
-      ],
-      "title": "Container Start Duration",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 30 },
-      "id": 9,
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(arl_warmpool_first_pod_ready_seconds_bucket[5m])))", "legendFormat": "p50 first pod" },
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(arl_warmpool_all_pods_ready_seconds_bucket[5m])))", "legendFormat": "p50 all pods" },
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(arl_warmpool_first_pod_ready_seconds_bucket[5m])))", "legendFormat": "p95 first pod" },
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(arl_warmpool_all_pods_ready_seconds_bucket[5m])))", "legendFormat": "p95 all pods" }
-      ],
-      "title": "Scale-out Readiness Duration",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 30 },
-      "id": 10,
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum by (reason) (rate(arl_warmpool_image_pull_errors_total[5m]))", "legendFormat": "pull error / {{reason}}" },
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum by (reason) (rate(arl_warmpool_pod_delete_total[5m]))", "legendFormat": "delete / {{reason}}" }
-      ],
-      "title": "Image Pull Errors & Pod Deletions Rate",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 38 },
-      "id": 102,
-      "title": "Sandbox",
-      "type": "row"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "orange", "value": 10 },
-            { "color": "red", "value": 50 }
-          ]},
-          "unit": "ops"
-        }
-      },
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 39 },
-      "id": 30,
-      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum(rate(workqueue_retries_total{name=\"sandbox\"}[5m]))", "legendFormat": "retry rate" }],
-      "title": "Sandbox Retry Rate",
-      "type": "stat"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": {
-          "color": { "mode": "thresholds" },
-          "thresholds": { "mode": "absolute", "steps": [
-            { "color": "green", "value": null },
-            { "color": "orange", "value": 0.5 },
-            { "color": "red", "value": 0.9 }
-          ]},
-          "unit": "percentunit",
-          "min": 0,
-          "max": 1
-        }
-      },
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 39 },
-      "id": 31,
-      "options": { "colorMode": "background", "graphMode": "area", "reduceOptions": { "calcs": ["lastNotNull"] } },
-      "targets": [{ "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum(rate(workqueue_retries_total{name=\"sandbox\"}[5m])) / clamp_min(sum(rate(workqueue_adds_total{name=\"sandbox\"}[5m])), 1)", "legendFormat": "ratio" }],
-      "title": "Sandbox Retry Ratio",
-      "type": "stat"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops", "custom": { "lineWidth": 2, "fillOpacity": 15 } }
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 39 },
-      "id": 32,
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] } },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum(rate(workqueue_adds_total{name=\"sandbox\"}[5m]))", "legendFormat": "adds" },
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum(rate(workqueue_retries_total{name=\"sandbox\"}[5m]))", "legendFormat": "retries" },
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum(rate(workqueue_adds_total{name=\"sandbox\"}[5m])) - sum(rate(workqueue_retries_total{name=\"sandbox\"}[5m]))", "legendFormat": "new events (adds - retries)" }
-      ],
-      "title": "Sandbox Workqueue: Adds vs Retries",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-      },
-      "gridPos": { "h": 4, "w": 12, "x": 0, "y": 43 },
-      "id": 11,
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean"] } },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(arl_sandbox_e2e_ready_seconds_bucket[5m])))", "legendFormat": "p50" },
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(arl_sandbox_e2e_ready_seconds_bucket[5m])))", "legendFormat": "p95" },
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(arl_sandbox_e2e_ready_seconds_bucket[5m])))", "legendFormat": "p99" }
-      ],
-      "title": "Sandbox E2E Ready Latency (user-visible)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-      },
-      "gridPos": { "h": 4, "w": 12, "x": 12, "y": 47 },
-      "id": 12,
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum(rate(arl_sandbox_no_idle_pods_total[5m]))", "legendFormat": "no-idle total" }
-      ],
-      "title": "No Idle Pods Rate (pool pressure)",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 47 },
-      "id": 103,
-      "title": "Gateway Execution",
-      "type": "row"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
-      "id": 13,
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean"] } },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(arl_gateway_step_duration_seconds_bucket[5m])))", "legendFormat": "p50" },
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(arl_gateway_step_duration_seconds_bucket[5m])))", "legendFormat": "p95" },
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.99, sum by (le) (rate(arl_gateway_step_duration_seconds_bucket[5m])))", "legendFormat": "p99" }
-      ],
-      "title": "Step Execution Duration",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
-      "id": 14,
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum by (result) (rate(arl_gateway_step_result_total[5m]))", "legendFormat": "{{result}}" }
-      ],
-      "title": "Step Result Rate (success / error)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 56 },
-      "id": 15,
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean"] } },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.50, sum by (method, le) (rate(arl_gateway_sidecar_call_seconds_bucket[5m])))", "legendFormat": "p50 {{method}}" },
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.95, sum by (method, le) (rate(arl_gateway_sidecar_call_seconds_bucket[5m])))", "legendFormat": "p95 {{method}}" }
-      ],
-      "title": "Sidecar gRPC Call Latency",
-      "type": "timeseries"
-    },
-    {
-      "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-      "fieldConfig": {
-        "defaults": { "color": { "mode": "palette-classic" }, "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-      },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 56 },
-      "id": 16,
-      "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean"] } },
-      "targets": [
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(arl_gateway_restore_duration_seconds_bucket[5m])))", "legendFormat": "restore p50" },
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(arl_gateway_restore_duration_seconds_bucket[5m])))", "legendFormat": "restore p95" },
-        { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum by (result) (rate(arl_gateway_restore_result_total[5m]))", "legendFormat": "restore {{result}}" }
-      ],
-      "title": "Restore Duration & Results",
-      "type": "timeseries"
-    },
-    {
-      "collapsed": true,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 64 },
-      "id": 104,
-      "title": "Controller Internals",
-      "type": "row",
-      "panels": [
-        {
-          "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 65 },
-          "id": 18,
-          "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "mean"] } },
-          "targets": [
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.50, sum by (controller, le) (rate(controller_runtime_reconcile_time_seconds_bucket[5m])))", "legendFormat": "p50 {{controller}}" },
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.95, sum by (controller, le) (rate(controller_runtime_reconcile_time_seconds_bucket[5m])))", "legendFormat": "p95 {{controller}}" },
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.99, sum by (controller, le) (rate(controller_runtime_reconcile_time_seconds_bucket[5m])))", "legendFormat": "p99 {{controller}}" }
-          ],
-          "title": "Reconcile Latency (controller-runtime)",
-          "type": "timeseries"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 65 },
-          "id": 19,
-          "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-          "targets": [
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "controller_runtime_active_workers", "legendFormat": "{{controller}}" }
-          ],
-          "title": "Active Reconcile Workers",
-          "type": "timeseries"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 73 },
-          "id": 20,
-          "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-          "targets": [
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum by (controller) (rate(controller_runtime_reconcile_errors_total[5m]))", "legendFormat": "errors {{controller}}" },
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum by (controller) (rate(controller_runtime_reconcile_panics_total[5m]))", "legendFormat": "panics {{controller}}" }
-          ],
-          "title": "Reconcile Errors & Panics",
-          "type": "timeseries"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 73 },
-          "id": 21,
-          "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-          "targets": [
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.50, sum by (le) (rate(arl_warmpool_pod_schedule_seconds_bucket[5m])))", "legendFormat": "p50" },
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.95, sum by (le) (rate(arl_warmpool_pod_schedule_seconds_bucket[5m])))", "legendFormat": "p95" }
-          ],
-          "title": "Pod Schedule Latency",
-          "type": "timeseries"
-        }
-      ]
-    },
-    {
-      "collapsed": true,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 65 },
-      "id": 105,
-      "title": "Workqueue",
-      "type": "row",
-      "panels": [
-        {
-          "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 20 } }
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 66 },
-          "id": 22,
-          "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull", "max"] } },
-          "targets": [
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "workqueue_depth", "legendFormat": "{{name}}" }
-          ],
-          "title": "Workqueue Depth",
-          "type": "timeseries"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 66 },
-          "id": 23,
-          "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-          "targets": [
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum by (name) (rate(workqueue_adds_total[5m]))", "legendFormat": "adds {{name}}" },
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum by (name) (rate(workqueue_retries_total[5m]))", "legendFormat": "retries {{name}}" }
-          ],
-          "title": "Workqueue Throughput & Retries",
-          "type": "timeseries"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 74 },
-          "id": 24,
-          "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-          "targets": [
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.50, sum by (name, le) (rate(workqueue_queue_duration_seconds_bucket[5m])))", "legendFormat": "p50 {{name}}" },
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "histogram_quantile(0.95, sum by (name, le) (rate(workqueue_queue_duration_seconds_bucket[5m])))", "legendFormat": "p95 {{name}}" }
-          ],
-          "title": "Queue Wait Duration",
-          "type": "timeseries"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "s", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 74 },
-          "id": 25,
-          "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-          "targets": [
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "workqueue_unfinished_work_seconds", "legendFormat": "unfinished {{name}}" },
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "workqueue_longest_running_processor_seconds", "legendFormat": "longest {{name}}" }
-          ],
-          "title": "Unfinished Work & Longest Processor",
-          "type": "timeseries"
-        }
-      ]
-    },
-    {
-      "collapsed": true,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 66 },
-      "id": 106,
-      "title": "Process Resources",
-      "type": "row",
-      "panels": [
-        {
-          "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "bytes", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 67 },
-          "id": 26,
-          "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-          "targets": [
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "process_resident_memory_bytes{job=\"arl\"}", "legendFormat": "RSS {{component}}" },
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "go_memstats_alloc_bytes{job=\"arl\"}", "legendFormat": "heap alloc {{component}}" }
-          ],
-          "title": "Memory Usage",
-          "type": "timeseries"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 67 },
-          "id": 27,
-          "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-          "targets": [
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "rate(process_cpu_seconds_total{job=\"arl\"}[5m])", "legendFormat": "CPU {{component}}" }
-          ],
-          "title": "CPU Usage (cores)",
-          "type": "timeseries"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "short", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 0, "y": 75 },
-          "id": 28,
-          "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-          "targets": [
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "go_goroutines{job=\"arl\"}", "legendFormat": "{{component}}" }
-          ],
-          "title": "Goroutines",
-          "type": "timeseries"
-        },
-        {
-          "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-          "fieldConfig": {
-            "defaults": { "color": { "mode": "palette-classic" }, "unit": "ops", "custom": { "lineWidth": 2, "fillOpacity": 10 } }
-          },
-          "gridPos": { "h": 8, "w": 12, "x": 12, "y": 75 },
-          "id": 29,
-          "options": { "tooltip": { "mode": "multi" }, "legend": { "displayMode": "table", "placement": "bottom", "calcs": ["lastNotNull"] } },
-          "targets": [
-            { "datasource": { "type": "prometheus", "uid": "arl-prometheus" }, "expr": "sum by (code, method) (rate(rest_client_requests_total[5m]))", "legendFormat": "{{method}} {{code}}" }
-          ],
-          "title": "K8s API Request Rate",
-          "type": "timeseries"
-        }
-      ]
-    }
-  ],
-  "refresh": "30s",
-  "schemaVersion": 39,
-  "tags": ["arl", "kubernetes", "operator", "gateway"],
-  "templating": {
-    "list": [
-      {
-        "current": {},
-        "hide": 0,
-        "includeAll": false,
-        "name": "datasource",
-        "query": "prometheus",
-        "refresh": 1,
-        "type": "datasource",
-        "label": "Data Source"
-      },
-      {
-        "current": {},
-        "datasource": { "type": "prometheus", "uid": "arl-prometheus" },
-        "definition": "label_values(arl_pool_utilization, pool)",
-        "hide": 0,
-        "includeAll": true,
-        "allValue": ".*",
-        "multi": true,
-        "name": "pool",
-        "query": { "query": "label_values(arl_pool_utilization, pool)", "refId": "StandardVariableQuery" },
-        "refresh": 2,
-        "regex": "",
-        "sort": 1,
-        "type": "query",
-        "label": "Pool"
-      }
-    ]
+ "annotations": {
+  "list": []
+ },
+ "description": "ARL Infra \u2014 Operator, Gateway, Pool & Sandbox monitoring",
+ "editable": true,
+ "graphTooltip": 1,
+ "links": [],
+ "panels": [
+  {
+   "collapsed": false,
+   "gridPos": {
+    "h": 1,
+    "w": 24,
+    "x": 0,
+    "y": 0
+   },
+   "id": 100,
+   "title": "Overview",
+   "type": "row"
   },
-  "time": { "from": "now-1h", "to": "now" },
-  "timepicker": {},
-  "timezone": "browser",
-  "title": "ARL Infra",
-  "uid": "arl-infra",
-  "version": 1
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "orange",
+        "value": 80
+       },
+       {
+        "color": "red",
+        "value": 100
+       }
+      ]
+     },
+     "mappings": [],
+     "unit": "short"
+    }
+   },
+   "gridPos": {
+    "h": 4,
+    "w": 4,
+    "x": 0,
+    "y": 1
+   },
+   "id": 1,
+   "options": {
+    "colorMode": "background",
+    "graphMode": "area",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum(arl_gateway_active_sessions)",
+     "legendFormat": "Sessions"
+    }
+   ],
+   "title": "Active Sessions",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "red",
+        "value": null
+       },
+       {
+        "color": "orange",
+        "value": 1
+       },
+       {
+        "color": "green",
+        "value": 3
+       }
+      ]
+     },
+     "unit": "short"
+    }
+   },
+   "gridPos": {
+    "h": 4,
+    "w": 4,
+    "x": 4,
+    "y": 1
+   },
+   "id": 2,
+   "options": {
+    "colorMode": "background",
+    "graphMode": "area",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum(arl_pool_utilization{status=\"ready\"})",
+     "legendFormat": "Ready"
+    }
+   ],
+   "title": "Pool Ready Pods",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "orange",
+        "value": 5
+       },
+       {
+        "color": "red",
+        "value": 10
+       }
+      ]
+     },
+     "unit": "short"
+    }
+   },
+   "gridPos": {
+    "h": 4,
+    "w": 4,
+    "x": 8,
+    "y": 1
+   },
+   "id": 3,
+   "options": {
+    "colorMode": "value",
+    "graphMode": "area",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum(arl_pool_utilization{status=\"allocated\"})",
+     "legendFormat": "Allocated"
+    }
+   ],
+   "title": "Allocated Pods",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "orange",
+        "value": 3
+       },
+       {
+        "color": "red",
+        "value": 10
+       }
+      ]
+     },
+     "unit": "short"
+    }
+   },
+   "gridPos": {
+    "h": 4,
+    "w": 4,
+    "x": 12,
+    "y": 1
+   },
+   "id": 4,
+   "options": {
+    "colorMode": "value",
+    "graphMode": "area",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum(arl_warmpool_pending_pods)",
+     "legendFormat": "Pending"
+    }
+   ],
+   "title": "Pending Pods",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "unit": "short",
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 10
+     }
+    }
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 5
+   },
+   "id": 5,
+   "options": {
+    "tooltip": {
+     "mode": "multi"
+    },
+    "legend": {
+     "displayMode": "table",
+     "placement": "bottom",
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum by (status) (arl_pool_utilization{pool=~\"$pool\"})",
+     "legendFormat": "{{status}}",
+     "interval": "15s"
+    }
+   ],
+   "title": "Pool Utilization",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "unit": "short",
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 10,
+      "stacking": {
+       "mode": "normal"
+      }
+     }
+    }
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 13
+   },
+   "id": 17,
+   "options": {
+    "tooltip": {
+     "mode": "multi"
+    },
+    "legend": {
+     "displayMode": "table",
+     "placement": "bottom",
+     "calcs": [
+      "lastNotNull"
+     ],
+     "sortBy": "Last *",
+     "sortDesc": true
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "topk(20, max_over_time(arl_pool_utilization{status=\"allocated\"}[1m]) > 0)",
+     "legendFormat": "{{pool}}",
+     "instant": false,
+     "interval": "30s"
+    }
+   ],
+   "title": "Top 20 Active Pools (allocated > 0)",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "unit": "ops",
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 10
+     }
+    }
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 5
+   },
+   "id": 6,
+   "options": {
+    "tooltip": {
+     "mode": "multi"
+    },
+    "legend": {
+     "displayMode": "table",
+     "placement": "bottom",
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum by (controller, result) (rate(arl_reconcile_total[5m]))",
+     "legendFormat": "{{controller}} / {{result}}"
+    }
+   ],
+   "title": "Reconcile Rate",
+   "type": "timeseries"
+  },
+  {
+   "collapsed": false,
+   "gridPos": {
+    "h": 1,
+    "w": 24,
+    "x": 0,
+    "y": 21
+   },
+   "id": 101,
+   "title": "Pod Lifecycle",
+   "type": "row"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "unit": "s",
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 10
+     }
+    }
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 22
+   },
+   "id": 7,
+   "options": {
+    "tooltip": {
+     "mode": "multi"
+    },
+    "legend": {
+     "displayMode": "table",
+     "placement": "bottom",
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.50, sum by (le) (rate(arl_warmpool_pod_ready_seconds_bucket[5m])))",
+     "legendFormat": "p50"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.95, sum by (le) (rate(arl_warmpool_pod_ready_seconds_bucket[5m])))",
+     "legendFormat": "p95"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.99, sum by (le) (rate(arl_warmpool_pod_ready_seconds_bucket[5m])))",
+     "legendFormat": "p99"
+    }
+   ],
+   "title": "Pod Ready Duration (creation\u2192ready)",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "unit": "s",
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 10
+     }
+    }
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 22
+   },
+   "id": 8,
+   "options": {
+    "tooltip": {
+     "mode": "multi"
+    },
+    "legend": {
+     "displayMode": "table",
+     "placement": "bottom",
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.50, sum by (container, le) (rate(arl_warmpool_container_start_seconds_bucket[5m])))",
+     "legendFormat": "p50 {{container}}"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.95, sum by (container, le) (rate(arl_warmpool_container_start_seconds_bucket[5m])))",
+     "legendFormat": "p95 {{container}}"
+    }
+   ],
+   "title": "Container Start Duration",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "unit": "s",
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 10
+     }
+    }
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 30
+   },
+   "id": 9,
+   "options": {
+    "tooltip": {
+     "mode": "multi"
+    },
+    "legend": {
+     "displayMode": "table",
+     "placement": "bottom",
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.50, sum by (le) (rate(arl_warmpool_first_pod_ready_seconds_bucket[5m])))",
+     "legendFormat": "p50 first pod"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.50, sum by (le) (rate(arl_warmpool_all_pods_ready_seconds_bucket[5m])))",
+     "legendFormat": "p50 all pods"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.95, sum by (le) (rate(arl_warmpool_first_pod_ready_seconds_bucket[5m])))",
+     "legendFormat": "p95 first pod"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.95, sum by (le) (rate(arl_warmpool_all_pods_ready_seconds_bucket[5m])))",
+     "legendFormat": "p95 all pods"
+    }
+   ],
+   "title": "Scale-out Readiness Duration",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "unit": "ops",
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 10
+     }
+    }
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 30
+   },
+   "id": 10,
+   "options": {
+    "tooltip": {
+     "mode": "multi"
+    },
+    "legend": {
+     "displayMode": "table",
+     "placement": "bottom",
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum by (reason) (rate(arl_warmpool_image_pull_errors_total[5m]))",
+     "legendFormat": "pull error / {{reason}}"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum by (reason) (rate(arl_warmpool_pod_delete_total[5m]))",
+     "legendFormat": "delete / {{reason}}"
+    }
+   ],
+   "title": "Image Pull Errors & Pod Deletions Rate",
+   "type": "timeseries"
+  },
+  {
+   "collapsed": false,
+   "gridPos": {
+    "h": 1,
+    "w": 24,
+    "x": 0,
+    "y": 38
+   },
+   "id": 102,
+   "title": "Sandbox",
+   "type": "row"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "orange",
+        "value": 10
+       },
+       {
+        "color": "red",
+        "value": 50
+       }
+      ]
+     },
+     "unit": "ops"
+    }
+   },
+   "gridPos": {
+    "h": 4,
+    "w": 6,
+    "x": 0,
+    "y": 39
+   },
+   "id": 30,
+   "options": {
+    "colorMode": "background",
+    "graphMode": "area",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum(rate(workqueue_retries_total{name=\"sandbox\"}[5m]))",
+     "legendFormat": "retry rate"
+    }
+   ],
+   "title": "Sandbox Retry Rate",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "thresholds"
+     },
+     "thresholds": {
+      "mode": "absolute",
+      "steps": [
+       {
+        "color": "green",
+        "value": null
+       },
+       {
+        "color": "orange",
+        "value": 0.5
+       },
+       {
+        "color": "red",
+        "value": 0.9
+       }
+      ]
+     },
+     "unit": "percentunit",
+     "min": 0,
+     "max": 1
+    }
+   },
+   "gridPos": {
+    "h": 4,
+    "w": 6,
+    "x": 6,
+    "y": 39
+   },
+   "id": 31,
+   "options": {
+    "colorMode": "background",
+    "graphMode": "area",
+    "reduceOptions": {
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum(rate(workqueue_retries_total{name=\"sandbox\"}[5m])) / clamp_min(sum(rate(workqueue_adds_total{name=\"sandbox\"}[5m])), 1)",
+     "legendFormat": "ratio"
+    }
+   ],
+   "title": "Sandbox Retry Ratio",
+   "type": "stat"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "unit": "ops",
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 15
+     }
+    }
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 39
+   },
+   "id": 32,
+   "options": {
+    "tooltip": {
+     "mode": "multi"
+    },
+    "legend": {
+     "displayMode": "table",
+     "placement": "bottom",
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum(rate(workqueue_adds_total{name=\"sandbox\"}[5m]))",
+     "legendFormat": "adds"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum(rate(workqueue_retries_total{name=\"sandbox\"}[5m]))",
+     "legendFormat": "retries"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum(rate(workqueue_adds_total{name=\"sandbox\"}[5m])) - sum(rate(workqueue_retries_total{name=\"sandbox\"}[5m]))",
+     "legendFormat": "new events (adds - retries)"
+    }
+   ],
+   "title": "Sandbox Workqueue: Adds vs Retries",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "unit": "s",
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 10
+     }
+    }
+   },
+   "gridPos": {
+    "h": 4,
+    "w": 12,
+    "x": 0,
+    "y": 43
+   },
+   "id": 11,
+   "options": {
+    "tooltip": {
+     "mode": "multi"
+    },
+    "legend": {
+     "displayMode": "table",
+     "placement": "bottom",
+     "calcs": [
+      "lastNotNull",
+      "mean"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.50, sum by (le) (rate(arl_sandbox_e2e_ready_seconds_bucket[5m])))",
+     "legendFormat": "p50"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.95, sum by (le) (rate(arl_sandbox_e2e_ready_seconds_bucket[5m])))",
+     "legendFormat": "p95"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.99, sum by (le) (rate(arl_sandbox_e2e_ready_seconds_bucket[5m])))",
+     "legendFormat": "p99"
+    }
+   ],
+   "title": "Sandbox E2E Ready Latency (user-visible)",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "unit": "ops",
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 10
+     }
+    }
+   },
+   "gridPos": {
+    "h": 4,
+    "w": 12,
+    "x": 12,
+    "y": 47
+   },
+   "id": 12,
+   "options": {
+    "tooltip": {
+     "mode": "multi"
+    },
+    "legend": {
+     "displayMode": "table",
+     "placement": "bottom",
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum(rate(arl_sandbox_no_idle_pods_total[5m]))",
+     "legendFormat": "no-idle total"
+    }
+   ],
+   "title": "No Idle Pods Rate (pool pressure)",
+   "type": "timeseries"
+  },
+  {
+   "collapsed": false,
+   "gridPos": {
+    "h": 1,
+    "w": 24,
+    "x": 0,
+    "y": 47
+   },
+   "id": 103,
+   "title": "Gateway Execution",
+   "type": "row"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "unit": "s",
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 10
+     }
+    }
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 48
+   },
+   "id": 13,
+   "options": {
+    "tooltip": {
+     "mode": "multi"
+    },
+    "legend": {
+     "displayMode": "table",
+     "placement": "bottom",
+     "calcs": [
+      "lastNotNull",
+      "mean"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.50, sum by (le) (rate(arl_gateway_step_duration_seconds_bucket[5m])))",
+     "legendFormat": "p50"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.95, sum by (le) (rate(arl_gateway_step_duration_seconds_bucket[5m])))",
+     "legendFormat": "p95"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.99, sum by (le) (rate(arl_gateway_step_duration_seconds_bucket[5m])))",
+     "legendFormat": "p99"
+    }
+   ],
+   "title": "Step Execution Duration",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "unit": "ops",
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 10
+     }
+    }
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 48
+   },
+   "id": 14,
+   "options": {
+    "tooltip": {
+     "mode": "multi"
+    },
+    "legend": {
+     "displayMode": "table",
+     "placement": "bottom",
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum by (result) (rate(arl_gateway_step_result_total[5m]))",
+     "legendFormat": "{{result}}"
+    }
+   ],
+   "title": "Step Result Rate (success / error)",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "unit": "s",
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 10
+     }
+    }
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 56
+   },
+   "id": 15,
+   "options": {
+    "tooltip": {
+     "mode": "multi"
+    },
+    "legend": {
+     "displayMode": "table",
+     "placement": "bottom",
+     "calcs": [
+      "lastNotNull",
+      "mean"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.50, sum by (method, le) (rate(arl_gateway_sidecar_call_seconds_bucket[5m])))",
+     "legendFormat": "p50 {{method}}"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.95, sum by (method, le) (rate(arl_gateway_sidecar_call_seconds_bucket[5m])))",
+     "legendFormat": "p95 {{method}}"
+    }
+   ],
+   "title": "Sidecar gRPC Call Latency",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "unit": "s",
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 10
+     }
+    }
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 56
+   },
+   "id": 16,
+   "options": {
+    "tooltip": {
+     "mode": "multi"
+    },
+    "legend": {
+     "displayMode": "table",
+     "placement": "bottom",
+     "calcs": [
+      "lastNotNull",
+      "mean"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.50, sum by (le) (rate(arl_gateway_restore_duration_seconds_bucket[5m])))",
+     "legendFormat": "restore p50"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.95, sum by (le) (rate(arl_gateway_restore_duration_seconds_bucket[5m])))",
+     "legendFormat": "restore p95"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum by (result) (rate(arl_gateway_restore_result_total[5m]))",
+     "legendFormat": "restore {{result}}"
+    }
+   ],
+   "title": "Restore Duration & Results",
+   "type": "timeseries"
+  },
+  {
+   "collapsed": true,
+   "gridPos": {
+    "h": 1,
+    "w": 24,
+    "x": 0,
+    "y": 64
+   },
+   "id": 104,
+   "title": "Controller Internals",
+   "type": "row",
+   "panels": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "fieldConfig": {
+      "defaults": {
+       "color": {
+        "mode": "palette-classic"
+       },
+       "unit": "s",
+       "custom": {
+        "lineWidth": 2,
+        "fillOpacity": 10
+       }
+      }
+     },
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 0,
+      "y": 65
+     },
+     "id": 18,
+     "options": {
+      "tooltip": {
+       "mode": "multi"
+      },
+      "legend": {
+       "displayMode": "table",
+       "placement": "bottom",
+       "calcs": [
+        "lastNotNull",
+        "mean"
+       ]
+      }
+     },
+     "targets": [
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "histogram_quantile(0.50, sum by (controller, le) (rate(controller_runtime_reconcile_time_seconds_bucket[5m])))",
+       "legendFormat": "p50 {{controller}}"
+      },
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "histogram_quantile(0.95, sum by (controller, le) (rate(controller_runtime_reconcile_time_seconds_bucket[5m])))",
+       "legendFormat": "p95 {{controller}}"
+      },
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "histogram_quantile(0.99, sum by (controller, le) (rate(controller_runtime_reconcile_time_seconds_bucket[5m])))",
+       "legendFormat": "p99 {{controller}}"
+      }
+     ],
+     "title": "Reconcile Latency (controller-runtime)",
+     "type": "timeseries"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "fieldConfig": {
+      "defaults": {
+       "color": {
+        "mode": "palette-classic"
+       },
+       "unit": "short",
+       "custom": {
+        "lineWidth": 2,
+        "fillOpacity": 10
+       }
+      }
+     },
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 12,
+      "y": 65
+     },
+     "id": 19,
+     "options": {
+      "tooltip": {
+       "mode": "multi"
+      },
+      "legend": {
+       "displayMode": "table",
+       "placement": "bottom",
+       "calcs": [
+        "lastNotNull"
+       ]
+      }
+     },
+     "targets": [
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "controller_runtime_active_workers",
+       "legendFormat": "{{controller}}"
+      }
+     ],
+     "title": "Active Reconcile Workers",
+     "type": "timeseries"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "fieldConfig": {
+      "defaults": {
+       "color": {
+        "mode": "palette-classic"
+       },
+       "unit": "ops",
+       "custom": {
+        "lineWidth": 2,
+        "fillOpacity": 10
+       }
+      }
+     },
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 0,
+      "y": 73
+     },
+     "id": 20,
+     "options": {
+      "tooltip": {
+       "mode": "multi"
+      },
+      "legend": {
+       "displayMode": "table",
+       "placement": "bottom",
+       "calcs": [
+        "lastNotNull"
+       ]
+      }
+     },
+     "targets": [
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "sum by (controller) (rate(controller_runtime_reconcile_errors_total[5m]))",
+       "legendFormat": "errors {{controller}}"
+      },
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "sum by (controller) (rate(controller_runtime_reconcile_panics_total[5m]))",
+       "legendFormat": "panics {{controller}}"
+      }
+     ],
+     "title": "Reconcile Errors & Panics",
+     "type": "timeseries"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "fieldConfig": {
+      "defaults": {
+       "color": {
+        "mode": "palette-classic"
+       },
+       "unit": "s",
+       "custom": {
+        "lineWidth": 2,
+        "fillOpacity": 10
+       }
+      }
+     },
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 12,
+      "y": 73
+     },
+     "id": 21,
+     "options": {
+      "tooltip": {
+       "mode": "multi"
+      },
+      "legend": {
+       "displayMode": "table",
+       "placement": "bottom",
+       "calcs": [
+        "lastNotNull"
+       ]
+      }
+     },
+     "targets": [
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "histogram_quantile(0.50, sum by (le) (rate(arl_warmpool_pod_schedule_seconds_bucket[5m])))",
+       "legendFormat": "p50"
+      },
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "histogram_quantile(0.95, sum by (le) (rate(arl_warmpool_pod_schedule_seconds_bucket[5m])))",
+       "legendFormat": "p95"
+      }
+     ],
+     "title": "Pod Schedule Latency",
+     "type": "timeseries"
+    }
+   ]
+  },
+  {
+   "collapsed": true,
+   "gridPos": {
+    "h": 1,
+    "w": 24,
+    "x": 0,
+    "y": 65
+   },
+   "id": 105,
+   "title": "Workqueue",
+   "type": "row",
+   "panels": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "fieldConfig": {
+      "defaults": {
+       "color": {
+        "mode": "palette-classic"
+       },
+       "unit": "short",
+       "custom": {
+        "lineWidth": 2,
+        "fillOpacity": 20
+       }
+      }
+     },
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 0,
+      "y": 66
+     },
+     "id": 22,
+     "options": {
+      "tooltip": {
+       "mode": "multi"
+      },
+      "legend": {
+       "displayMode": "table",
+       "placement": "bottom",
+       "calcs": [
+        "lastNotNull",
+        "max"
+       ]
+      }
+     },
+     "targets": [
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "workqueue_depth",
+       "legendFormat": "{{name}}"
+      }
+     ],
+     "title": "Workqueue Depth",
+     "type": "timeseries"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "fieldConfig": {
+      "defaults": {
+       "color": {
+        "mode": "palette-classic"
+       },
+       "unit": "ops",
+       "custom": {
+        "lineWidth": 2,
+        "fillOpacity": 10
+       }
+      }
+     },
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 12,
+      "y": 66
+     },
+     "id": 23,
+     "options": {
+      "tooltip": {
+       "mode": "multi"
+      },
+      "legend": {
+       "displayMode": "table",
+       "placement": "bottom",
+       "calcs": [
+        "lastNotNull"
+       ]
+      }
+     },
+     "targets": [
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "sum by (name) (rate(workqueue_adds_total[5m]))",
+       "legendFormat": "adds {{name}}"
+      },
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "sum by (name) (rate(workqueue_retries_total[5m]))",
+       "legendFormat": "retries {{name}}"
+      }
+     ],
+     "title": "Workqueue Throughput & Retries",
+     "type": "timeseries"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "fieldConfig": {
+      "defaults": {
+       "color": {
+        "mode": "palette-classic"
+       },
+       "unit": "s",
+       "custom": {
+        "lineWidth": 2,
+        "fillOpacity": 10
+       }
+      }
+     },
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 0,
+      "y": 74
+     },
+     "id": 24,
+     "options": {
+      "tooltip": {
+       "mode": "multi"
+      },
+      "legend": {
+       "displayMode": "table",
+       "placement": "bottom",
+       "calcs": [
+        "lastNotNull"
+       ]
+      }
+     },
+     "targets": [
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "histogram_quantile(0.50, sum by (name, le) (rate(workqueue_queue_duration_seconds_bucket[5m])))",
+       "legendFormat": "p50 {{name}}"
+      },
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "histogram_quantile(0.95, sum by (name, le) (rate(workqueue_queue_duration_seconds_bucket[5m])))",
+       "legendFormat": "p95 {{name}}"
+      }
+     ],
+     "title": "Queue Wait Duration",
+     "type": "timeseries"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "fieldConfig": {
+      "defaults": {
+       "color": {
+        "mode": "palette-classic"
+       },
+       "unit": "s",
+       "custom": {
+        "lineWidth": 2,
+        "fillOpacity": 10
+       }
+      }
+     },
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 12,
+      "y": 74
+     },
+     "id": 25,
+     "options": {
+      "tooltip": {
+       "mode": "multi"
+      },
+      "legend": {
+       "displayMode": "table",
+       "placement": "bottom",
+       "calcs": [
+        "lastNotNull"
+       ]
+      }
+     },
+     "targets": [
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "workqueue_unfinished_work_seconds",
+       "legendFormat": "unfinished {{name}}"
+      },
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "workqueue_longest_running_processor_seconds",
+       "legendFormat": "longest {{name}}"
+      }
+     ],
+     "title": "Unfinished Work & Longest Processor",
+     "type": "timeseries"
+    }
+   ]
+  },
+  {
+   "collapsed": true,
+   "gridPos": {
+    "h": 1,
+    "w": 24,
+    "x": 0,
+    "y": 66
+   },
+   "id": 106,
+   "title": "Process Resources",
+   "type": "row",
+   "panels": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "fieldConfig": {
+      "defaults": {
+       "color": {
+        "mode": "palette-classic"
+       },
+       "unit": "bytes",
+       "custom": {
+        "lineWidth": 2,
+        "fillOpacity": 10
+       }
+      }
+     },
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 0,
+      "y": 67
+     },
+     "id": 26,
+     "options": {
+      "tooltip": {
+       "mode": "multi"
+      },
+      "legend": {
+       "displayMode": "table",
+       "placement": "bottom",
+       "calcs": [
+        "lastNotNull"
+       ]
+      }
+     },
+     "targets": [
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "process_resident_memory_bytes{job=\"arl\"}",
+       "legendFormat": "RSS {{component}}"
+      },
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "go_memstats_alloc_bytes{job=\"arl\"}",
+       "legendFormat": "heap alloc {{component}}"
+      }
+     ],
+     "title": "Memory Usage",
+     "type": "timeseries"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "fieldConfig": {
+      "defaults": {
+       "color": {
+        "mode": "palette-classic"
+       },
+       "unit": "short",
+       "custom": {
+        "lineWidth": 2,
+        "fillOpacity": 10
+       }
+      }
+     },
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 12,
+      "y": 67
+     },
+     "id": 27,
+     "options": {
+      "tooltip": {
+       "mode": "multi"
+      },
+      "legend": {
+       "displayMode": "table",
+       "placement": "bottom",
+       "calcs": [
+        "lastNotNull"
+       ]
+      }
+     },
+     "targets": [
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "rate(process_cpu_seconds_total{job=\"arl\"}[5m])",
+       "legendFormat": "CPU {{component}}"
+      }
+     ],
+     "title": "CPU Usage (cores)",
+     "type": "timeseries"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "fieldConfig": {
+      "defaults": {
+       "color": {
+        "mode": "palette-classic"
+       },
+       "unit": "short",
+       "custom": {
+        "lineWidth": 2,
+        "fillOpacity": 10
+       }
+      }
+     },
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 0,
+      "y": 75
+     },
+     "id": 28,
+     "options": {
+      "tooltip": {
+       "mode": "multi"
+      },
+      "legend": {
+       "displayMode": "table",
+       "placement": "bottom",
+       "calcs": [
+        "lastNotNull"
+       ]
+      }
+     },
+     "targets": [
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "go_goroutines{job=\"arl\"}",
+       "legendFormat": "{{component}}"
+      }
+     ],
+     "title": "Goroutines",
+     "type": "timeseries"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "fieldConfig": {
+      "defaults": {
+       "color": {
+        "mode": "palette-classic"
+       },
+       "unit": "ops",
+       "custom": {
+        "lineWidth": 2,
+        "fillOpacity": 10
+       }
+      }
+     },
+     "gridPos": {
+      "h": 8,
+      "w": 12,
+      "x": 12,
+      "y": 75
+     },
+     "id": 29,
+     "options": {
+      "tooltip": {
+       "mode": "multi"
+      },
+      "legend": {
+       "displayMode": "table",
+       "placement": "bottom",
+       "calcs": [
+        "lastNotNull"
+       ]
+      }
+     },
+     "targets": [
+      {
+       "datasource": {
+        "type": "prometheus",
+        "uid": "arl-prometheus"
+       },
+       "expr": "sum by (code, method) (rate(rest_client_requests_total[5m]))",
+       "legendFormat": "{{method}} {{code}}"
+      }
+     ],
+     "title": "K8s API Request Rate",
+     "type": "timeseries"
+    }
+   ]
+  },
+  {
+   "type": "row",
+   "collapsed": false,
+   "title": "Image Cache & Pull Time",
+   "gridPos": {
+    "h": 1,
+    "w": 24,
+    "x": 0,
+    "y": 67
+   },
+   "id": 107,
+   "panels": []
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "unit": "percentunit",
+     "min": 0,
+     "max": 1,
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 10
+     }
+    }
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 0,
+    "y": 68
+   },
+   "id": 108,
+   "options": {
+    "tooltip": {
+     "mode": "multi"
+    },
+    "legend": {
+     "displayMode": "table",
+     "placement": "bottom",
+     "calcs": [
+      "lastNotNull"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum(rate(arl_warmpool_image_pull_seconds_count{result=\"hit\"}[5m])) / clamp_min(sum(rate(arl_warmpool_image_pull_seconds_count[5m])), 0.0001)",
+     "legendFormat": "hit rate (all pools)"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum by (pool) (rate(arl_warmpool_image_pull_seconds_count{result=\"hit\"}[5m])) / clamp_min(sum by (pool) (rate(arl_warmpool_image_pull_seconds_count[5m])), 0.0001)",
+     "legendFormat": "{{pool}}"
+    }
+   ],
+   "title": "Image Pull Cache Hit Rate",
+   "type": "timeseries"
+  },
+  {
+   "datasource": {
+    "type": "prometheus",
+    "uid": "arl-prometheus"
+   },
+   "fieldConfig": {
+    "defaults": {
+     "color": {
+      "mode": "palette-classic"
+     },
+     "unit": "s",
+     "custom": {
+      "lineWidth": 2,
+      "fillOpacity": 10
+     }
+    }
+   },
+   "gridPos": {
+    "h": 8,
+    "w": 12,
+    "x": 12,
+    "y": 68
+   },
+   "id": 109,
+   "options": {
+    "tooltip": {
+     "mode": "multi"
+    },
+    "legend": {
+     "displayMode": "table",
+     "placement": "bottom",
+     "calcs": [
+      "lastNotNull",
+      "max"
+     ]
+    }
+   },
+   "targets": [
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.5, sum by (le) (rate(arl_warmpool_image_pull_seconds_bucket{result=\"miss\"}[5m])))",
+     "legendFormat": "p50 pull (miss)"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "histogram_quantile(0.95, sum by (le) (rate(arl_warmpool_image_pull_seconds_bucket{result=\"miss\"}[5m])))",
+     "legendFormat": "p95 pull (miss)"
+    },
+    {
+     "datasource": {
+      "type": "prometheus",
+      "uid": "arl-prometheus"
+     },
+     "expr": "sum(rate(arl_warmpool_image_pull_seconds_sum{result=\"miss\"}[5m])) / clamp_min(sum(rate(arl_warmpool_image_pull_seconds_count{result=\"miss\"}[5m])), 0.0001)",
+     "legendFormat": "avg pull (miss)"
+    }
+   ],
+   "title": "Image Pull Duration \u2014 miss (p50 / p95 / avg)",
+   "type": "timeseries"
+  }
+ ],
+ "refresh": "30s",
+ "schemaVersion": 39,
+ "tags": [
+  "arl",
+  "kubernetes",
+  "operator",
+  "gateway"
+ ],
+ "templating": {
+  "list": [
+   {
+    "current": {},
+    "hide": 0,
+    "includeAll": false,
+    "name": "datasource",
+    "query": "prometheus",
+    "refresh": 1,
+    "type": "datasource",
+    "label": "Data Source"
+   },
+   {
+    "current": {},
+    "datasource": {
+     "type": "prometheus",
+     "uid": "arl-prometheus"
+    },
+    "definition": "label_values(arl_pool_utilization, pool)",
+    "hide": 0,
+    "includeAll": true,
+    "allValue": ".*",
+    "multi": true,
+    "name": "pool",
+    "query": {
+     "query": "label_values(arl_pool_utilization, pool)",
+     "refId": "StandardVariableQuery"
+    },
+    "refresh": 2,
+    "regex": "",
+    "sort": 1,
+    "type": "query",
+    "label": "Pool"
+   }
+  ]
+ },
+ "time": {
+  "from": "now-1h",
+  "to": "now"
+ },
+ "timepicker": {},
+ "timezone": "browser",
+ "title": "ARL Infra",
+ "uid": "arl-infra",
+ "version": 1
 }

--- a/charts/arl-operator/templates/clusterrole.yaml
+++ b/charts/arl-operator/templates/clusterrole.yaml
@@ -60,6 +60,9 @@ rules:
     verbs:
       - create
       - patch
+      - get
+      - list
+      - watch
   - apiGroups:
       - coordination.k8s.io
     resources:

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -7,10 +7,14 @@ import (
 	"time"
 
 	_ "github.com/ClickHouse/clickhouse-go/v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -94,6 +98,15 @@ func main() {
 		HealthProbeBindAddress: cfg.ProbeAddr,
 		LeaderElection:         cfg.EnableLeaderElection,
 		LeaderElectionID:       "arl-operator.infra.io",
+		// Restrict the Event cache to image-pull events so the ImagePullObserver
+		// can watch them without caching every cluster Event in memory.
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Event{}: {
+					Field: fields.SelectorFromSet(fields.Set{"reason": "Pulled"}),
+				},
+			},
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -157,6 +170,10 @@ func main() {
 			Metrics:        metricsCollector,
 			Middleware:     warmPoolMiddleware,
 			ImageScheduler: imageScheduler,
+		},
+		&controller.ImagePullObserver{
+			Client:  mgr.GetClient(),
+			Metrics: metricsCollector,
 		},
 	}
 

--- a/examples/python/bench_gateway.py
+++ b/examples/python/bench_gateway.py
@@ -19,12 +19,19 @@ Usage:
 from __future__ import annotations
 
 import atexit
+import contextlib
+import json
+import math
+import re
 import shutil
 import signal
 import statistics
 import subprocess
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from datetime import datetime
+from typing import cast
 from urllib.parse import urlparse
 
 import typer
@@ -1157,6 +1164,564 @@ def full(
     )
 
     console.rule("[bold green]All Benchmarks Complete")
+
+
+# =========================================================================
+# image-bench: image pull speed / startup speed / cache-hit rate
+# =========================================================================
+#
+# Goal: large images, want fast startup, but cannot pre-warm too many.
+# This command measures the trade-off triangle directly:
+#   pre-warm count (cost) <-> cold-start tail latency <-> cache-hit rate.
+#
+# Cache-hit is computed two complementary ways:
+#   1. Authoritative: snapshot node.status.images BEFORE creating the pool,
+#      then per pod check whether its node already had the image (robust,
+#      does not depend on event retention).
+#   2. Pull time: parse kubelet "Pulled" events for the real pull seconds on
+#      a miss ("Successfully pulled image X in <dur>") vs "already present".
+
+# Default SWE-bench public image (large, ~multi-GB). Override with --image.
+DEFAULT_SWEBENCH_IMAGE = "swebench/swesmith.x86_64.emotion_1776_js-emotion.b882bcba"
+
+POOL_LABEL = "arl.infra.io/pool"
+
+_PULL_DUR_RE = re.compile(r"pulled image .* in ([0-9hmsµun.]+)")
+_PULL_SIZE_RE = re.compile(r"[Ii]mage size:\s*(\d+)\s*bytes")
+_GO_DUR_RE = re.compile(r"([0-9.]+)(ms|µs|us|ns|h|m|s)")
+
+
+@dataclass
+class PodObs:
+    """Per-pod observation for the image benchmark."""
+
+    name: str
+    node: str
+    ready_s: float | None
+    cache_hit: bool | None  # from node pre-snapshot (authoritative)
+    pull_result: str | None  # "hit" / "miss" from kubelet events
+    pull_s: float | None
+
+
+# ---------------------------------------------------------------------------
+# kubectl + parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def _kubectl_json(args: list[str], timeout: float = 30.0) -> dict[str, object]:
+    proc = subprocess.run(
+        ["kubectl", *args, "-o", "json"],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"kubectl {' '.join(args)} failed: {proc.stderr.strip()}")
+    parsed: dict[str, object] = json.loads(proc.stdout)
+    return parsed
+
+
+def _kubectl_apply(obj: dict[str, object], timeout: float = 30.0) -> None:
+    proc = subprocess.run(
+        ["kubectl", "apply", "-f", "-"],
+        input=json.dumps(obj),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"kubectl apply failed: {proc.stderr.strip()}")
+
+
+def _norm_image(img: str) -> str:
+    """Add :latest when no tag/digest is present (mirrors operator behaviour)."""
+    if "@" in img or ":" in img.rsplit("/", 1)[-1]:
+        return img
+    return img + ":latest"
+
+
+def _go_duration_seconds(s: str) -> float:
+    total = 0.0
+    unit = {"h": 3600.0, "m": 60.0, "s": 1.0, "ms": 1e-3, "us": 1e-6, "µs": 1e-6, "ns": 1e-9}
+    for num, u in _GO_DUR_RE.findall(s):
+        total += float(num) * unit[u]
+    return total
+
+
+def parse_pulled(msg: str) -> tuple[str, float, int]:
+    """Classify a kubelet 'Pulled' event message -> (result, seconds, size_bytes)."""
+    if "already present on machine" in msg:
+        return "hit", 0.0, 0
+    secs = 0.0
+    m = _PULL_DUR_RE.search(msg)
+    if m:
+        secs = _go_duration_seconds(m.group(1))
+    size = 0
+    ms = _PULL_SIZE_RE.search(msg)
+    if ms:
+        size = int(ms.group(1))
+    return "miss", secs, size
+
+
+def _parse_ts(ts: str) -> datetime:
+    return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+def snapshot_node_images(image: str) -> tuple[set[str], int]:
+    """Return (node names that already cache `image`, max known image size bytes)."""
+    data = _kubectl_json(["get", "nodes"])
+    items = cast(list[dict[str, object]], data.get("items", []))
+    want = _norm_image(image)
+    nodes: set[str] = set()
+    size = 0
+    for node in items:
+        meta = cast(dict[str, object], node.get("metadata", {}))
+        name = cast(str, meta.get("name", "") or "")
+        status = cast(dict[str, object], node.get("status", {}))
+        images = cast(list[dict[str, object]], status.get("images", []) or [])
+        for img in images:
+            names = cast(list[str], img.get("names", []) or [])
+            if any(_norm_image(n) == want or n == image for n in names):
+                nodes.add(name)
+                sb = img.get("sizeBytes")
+                if isinstance(sb, int):
+                    size = max(size, sb)
+                break
+    return nodes, size
+
+
+def apply_warmpool(
+    name: str,
+    image: str,
+    replicas: int,
+    namespace: str,
+    spread_factor: float | None = None,
+    node_hostname: str | None = None,
+) -> None:
+    """Create/update a WarmPool CRD directly (full control over imageLocality)."""
+    container: dict[str, object] = {
+        "name": "executor",
+        "image": image,
+        # IfNotPresent so a cached image is honoured — required for clean hit/miss.
+        "imagePullPolicy": "IfNotPresent",
+        "command": ["/bin/sh", "-c", "sleep infinity"],
+        "volumeMounts": [{"name": "workspace", "mountPath": "/workspace"}],
+    }
+    pod_spec: dict[str, object] = {
+        "containers": [container],
+        "volumes": [{"name": "workspace", "emptyDir": {}}],
+    }
+    if node_hostname:
+        pod_spec["nodeSelector"] = {"kubernetes.io/hostname": node_hostname}
+    spec: dict[str, object] = {
+        "replicas": replicas,
+        "template": {"spec": pod_spec},
+    }
+    if spread_factor is not None:
+        spec["imageLocality"] = {"enabled": True, "spreadFactor": spread_factor}
+    obj: dict[str, object] = {
+        "apiVersion": "arl.infra.io/v1alpha1",
+        "kind": "WarmPool",
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": spec,
+    }
+    _kubectl_apply(obj)
+
+
+def delete_warmpool_k(name: str, namespace: str) -> None:
+    subprocess.run(
+        ["kubectl", "delete", "warmpool", name, "-n", namespace, "--ignore-not-found"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+def list_pool_pods(namespace: str, pool: str) -> list[dict[str, object]]:
+    data = _kubectl_json(["get", "pods", "-n", namespace, "-l", f"{POOL_LABEL}={pool}"])
+    return cast(list[dict[str, object]], data.get("items", []))
+
+
+def _pod_name(obj: dict[str, object]) -> str:
+    meta = cast(dict[str, object], obj.get("metadata", {}))
+    return cast(str, meta.get("name", "") or "")
+
+
+def _pod_node(pod: dict[str, object]) -> str:
+    spec = cast(dict[str, object], pod.get("spec", {}))
+    return cast(str, spec.get("nodeName", "") or "")
+
+
+def _pod_ready(pod: dict[str, object]) -> bool:
+    status = cast(dict[str, object], pod.get("status", {}))
+    if status.get("phase") != "Running":
+        return False
+    css = cast(list[dict[str, object]], status.get("containerStatuses", []) or [])
+    return bool(css) and all(bool(cs.get("ready")) for cs in css)
+
+
+def _pod_failed(pod: dict[str, object]) -> str | None:
+    """Return a failure reason (ImagePullBackOff/ErrImagePull/...) or None."""
+    status = cast(dict[str, object], pod.get("status", {}))
+    groups = ["initContainerStatuses", "containerStatuses"]
+    for g in groups:
+        for cs in cast(list[dict[str, object]], status.get(g, []) or []):
+            state = cast(dict[str, object], cs.get("state", {}))
+            waiting = cast(dict[str, object], state.get("waiting", {}) or {})
+            reason = cast(str, waiting.get("reason", "") or "")
+            if reason in ("ImagePullBackOff", "ErrImagePull", "CrashLoopBackOff"):
+                return reason
+    return None
+
+
+def pod_ready_seconds(pod: dict[str, object]) -> float | None:
+    meta = cast(dict[str, object], pod.get("metadata", {}))
+    created = cast(str, meta.get("creationTimestamp", "") or "")
+    status = cast(dict[str, object], pod.get("status", {}))
+    conds = cast(list[dict[str, object]], status.get("conditions", []) or [])
+    if not created:
+        return None
+    for c in conds:
+        if c.get("type") == "Ready" and c.get("status") == "True":
+            ltt = cast(str, c.get("lastTransitionTime", "") or "")
+            if ltt:
+                return (_parse_ts(ltt) - _parse_ts(created)).total_seconds()
+    return None
+
+
+def wait_pool_pods_ready(
+    namespace: str,
+    pool: str,
+    want: int,
+    timeout: float,
+    poll: float = 3.0,
+) -> tuple[list[dict[str, object]], dict[str, str]]:
+    """Poll until `want` pods are ready or timeout. Returns (pods, failures)."""
+    deadline = time.monotonic() + timeout
+    pods: list[dict[str, object]] = []
+    failures: dict[str, str] = {}
+    while time.monotonic() < deadline:
+        pods = list_pool_pods(namespace, pool)
+        ready = sum(1 for p in pods if _pod_ready(p))
+        for p in pods:
+            reason = _pod_failed(p)
+            if reason:
+                failures[_pod_name(p)] = reason
+        if ready >= want:
+            return pods, failures
+        time.sleep(poll)
+    return pods, failures
+
+
+def pull_events(
+    namespace: str,
+    image: str,
+    pod_names: list[str],
+) -> dict[str, tuple[str, float, int]]:
+    """Map pod -> (result, seconds, size_bytes) for the user image's Pulled event."""
+    try:
+        data = _kubectl_json(
+            ["get", "events", "-n", namespace, "--field-selector", "reason=Pulled"]
+        )
+    except RuntimeError:
+        return {}
+    items = cast(list[dict[str, object]], data.get("items", []))
+    names = set(pod_names)
+    repo = _norm_image(image).split("@")[0].split(":")[0]
+    out: dict[str, tuple[str, float, int]] = {}
+    for ev in items:
+        involved = cast(dict[str, object], ev.get("involvedObject", {}))
+        if involved.get("kind") != "Pod":
+            continue
+        pod = cast(str, involved.get("name", "") or "")
+        if pod not in names:
+            continue
+        msg = cast(str, ev.get("message", "") or "")
+        if repo not in msg:
+            continue  # ignore sidecar / executor-agent pulls
+        result, secs, size = parse_pulled(msg)
+        prev = out.get(pod)
+        if prev is None or secs > prev[1]:
+            out[pod] = (result, secs, size)
+    return out
+
+
+def collect_pod_obs(
+    namespace: str,
+    pool: str,
+    image: str,
+    nodes_with_image: set[str],
+    pods: list[dict[str, object]],
+) -> list[PodObs]:
+    names = [_pod_name(p) for p in pods]
+    events = pull_events(namespace, image, names)
+    obs: list[PodObs] = []
+    for p in pods:
+        name = _pod_name(p)
+        node = _pod_node(p)
+        ev = events.get(name)
+        obs.append(
+            PodObs(
+                name=name,
+                node=node,
+                ready_s=pod_ready_seconds(p),
+                cache_hit=(node in nodes_with_image) if node else None,
+                pull_result=ev[0] if ev else None,
+                pull_s=ev[1] if ev else None,
+            )
+        )
+    return obs
+
+
+def _fmt_bytes(n: int) -> str:
+    f = float(n)
+    for unit in ["B", "KiB", "MiB", "GiB", "TiB"]:
+        if f < 1024 or unit == "TiB":
+            return f"{f:.1f}{unit}"
+        f /= 1024
+    return f"{f:.1f}TiB"
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+
+def _scenario_cold(image: str, replicas: int, namespace: str, timeout: float) -> None:
+    console.rule("[bold]Scenario 1: large-image cold pull")
+    pool = "imgbench-cold"
+    delete_warmpool_k(pool, namespace)
+    time.sleep(3)
+
+    nodes_with, presize = snapshot_node_images(image)
+    console.print(
+        f"  image already cached on [cyan]{len(nodes_with)}[/cyan] node(s) before start"
+        + (f"  (size {_fmt_bytes(presize)})" if presize else "")
+    )
+    console.print(f"  creating pool [cyan]{pool}[/cyan] replicas={replicas} (spreadFactor=1.0)...")
+    # spreadFactor=1.0 => spread widely so we land on cold nodes and observe real pulls.
+    apply_warmpool(pool, image, replicas, namespace, spread_factor=1.0)
+
+    pods, failures = wait_pool_pods_ready(namespace, pool, replicas, timeout)
+    obs = collect_pod_obs(namespace, pool, image, nodes_with, pods)
+
+    names = [o.name for o in obs]
+    ev_map = pull_events(namespace, image, names)
+    miss = [o for o in obs if o.pull_result == "miss" and o.pull_s and o.pull_s > 0]
+    hit = [o for o in obs if o.pull_result == "hit"]
+    pull_times = [o.pull_s for o in miss if o.pull_s is not None]
+    ready_times = [o.ready_s * 1000 for o in obs if o.ready_s is not None]
+    sizes = [ev_map[o.name][2] for o in miss if o.name in ev_map]
+    size = max([presize, *sizes]) if (sizes or presize) else 0
+
+    console.print()
+    rows: list[tuple[str, list[float]]] = []
+    if pull_times:
+        rows.append(("Image pull (miss)", [t * 1000 for t in pull_times]))
+    if ready_times:
+        rows.append(("Pod creation→ready", ready_times))
+    if rows:
+        console.print(stats_table("Cold Pull Results", rows))
+    console.print(
+        f"\n  pods={len(obs)}  fresh-pull(miss)={len(miss)}  cache-hit={len(hit)}  "
+        f"failed={len(failures)}"
+    )
+    if size and pull_times:
+        med_pull = statistics.median(pull_times)
+        if med_pull > 0:
+            bw = size / med_pull
+            console.print(
+                f"  image size ~{_fmt_bytes(size)}  median pull {fmt(med_pull * 1000)}  "
+                f"effective ~{_fmt_bytes(int(bw))}/s"
+            )
+    if failures:
+        uniq: dict[str, int] = {}
+        for r in failures.values():
+            uniq[r] = uniq.get(r, 0) + 1
+        console.print(f"  [red]pull failures:[/red] {uniq}")
+    delete_warmpool_k(pool, namespace)
+
+
+def _scenario_spread(
+    image: str,
+    replicas: int,
+    namespace: str,
+    timeout: float,
+    factors: list[float],
+) -> None:
+    console.rule("[bold]Scenario 2: cache-hit rate vs spreadFactor")
+    console.print(
+        "  [dim]note: the image stays cached across runs, so absolute hit-rate climbs over\n"
+        "  the sweep; the locality signal is unique-nodes and all-ready time.[/dim]\n"
+    )
+    table = Table(title=f"spreadFactor sweep (replicas={replicas})", show_lines=True)
+    table.add_column("spreadFactor", style="cyan")
+    table.add_column("k (pref nodes)", justify="right")
+    table.add_column("unique nodes", justify="right")
+    table.add_column("cache-hit", justify="right", style="green")
+    table.add_column("ready p50", justify="right")
+    table.add_column("ready p95", justify="right", style="magenta")
+
+    for sf in factors:
+        pool = f"imgbench-sf-{str(sf).replace('.', '-')}"
+        delete_warmpool_k(pool, namespace)
+        time.sleep(2)
+        nodes_with, _ = snapshot_node_images(image)
+        apply_warmpool(pool, image, replicas, namespace, spread_factor=sf)
+        pods, _ = wait_pool_pods_ready(namespace, pool, replicas, timeout)
+        obs = collect_pod_obs(namespace, pool, image, nodes_with, pods)
+        used_nodes = {o.node for o in obs if o.node}
+        hits = [o for o in obs if o.cache_hit]
+        hit_rate = (len(hits) / len(obs) * 100) if obs else 0.0
+        rt = sorted(o.ready_s for o in obs if o.ready_s is not None)
+        p50 = rt[len(rt) // 2] if rt else 0.0
+        p95 = rt[min(len(rt) - 1, int(len(rt) * 0.95))] if rt else 0.0
+        k = max(1, math.ceil(replicas * sf))
+        table.add_row(
+            str(sf),
+            str(k),
+            str(len(used_nodes)),
+            f"{hit_rate:.0f}%",
+            fmt(p50 * 1000),
+            fmt(p95 * 1000),
+        )
+        console.print(f"  [dim]sf={sf}: {len(used_nodes)} nodes, hit {hit_rate:.0f}%[/dim]")
+        delete_warmpool_k(pool, namespace)
+    console.print()
+    console.print(table)
+
+
+def _scenario_prewarm(
+    image: str,
+    namespace: str,
+    gateway_url: str,
+    timeout: float,
+    levels: list[int],
+) -> None:
+    console.rule("[bold]Scenario 3: pre-warm buffer vs cold-start tail")
+    console.print(
+        "  [dim]managed sessions auto-create/scale a pool; concurrency beyond the warm\n"
+        "  buffer pays the cold image pull as acquisition latency.[/dim]\n"
+    )
+    client = GatewayClient(base_url=gateway_url, timeout=timeout)
+    exp_base = f"imgbench-prewarm-{int(time.time())}"
+    rows: list[tuple[str, list[float]]] = []
+    for lvl in levels:
+        exp = f"{exp_base}-{lvl}"
+        console.print(f"  level=[cyan]{lvl}[/cyan] concurrent sessions...")
+        acq: list[float] = []
+        errs = 0
+
+        def _one(_i: int, exp_id: str = exp, n: int = lvl) -> tuple[float, bool]:
+            t = Timer()
+            try:
+                with t:
+                    client.create_managed_session(
+                        image=image,
+                        experiment_id=exp_id,
+                        namespace=namespace,
+                        max_replicas=n,
+                    )
+                return t.ms, True
+            except Exception:
+                return t.ms, False
+
+        with ThreadPoolExecutor(max_workers=lvl) as pool:
+            for ms, ok in pool.map(_one, range(lvl)):
+                acq.append(ms)
+                if not ok:
+                    errs += 1
+        rows.append((f"acquire @ {lvl} concurrent (err={errs})", acq))
+        with contextlib.suppress(Exception):
+            client.delete_experiment(exp)
+        time.sleep(3)
+    console.print()
+    console.print(stats_table("Managed Session Acquisition Latency", rows))
+
+
+def _scenario_hitmiss(image: str, namespace: str, timeout: float) -> None:
+    console.rule("[bold]Scenario 4: cache-hit vs miss (pod ready time)")
+    nodes_with, _ = snapshot_node_images(image)
+    all_nodes_data = _kubectl_json(["get", "nodes"])
+    all_nodes = [
+        _pod_name(n)
+        for n in cast(list[dict[str, object]], all_nodes_data.get("items", []))
+    ]
+    cold_nodes = [n for n in all_nodes if n and n not in nodes_with]
+    warm_node = next(iter(nodes_with), None)
+    cold_node = cold_nodes[0] if cold_nodes else None
+    if not warm_node or not cold_node:
+        console.print(
+            "  [yellow]need at least one warm and one cold node; "
+            f"warm={len(nodes_with)} cold={len(cold_nodes)}. Run scenario 1 first.[/yellow]"
+        )
+        return
+
+    results: list[tuple[str, str, float | None, str | None]] = []
+    for label, node in [("cache-hit", warm_node), ("cache-miss(cold)", cold_node)]:
+        pool = f"imgbench-{label.split('(')[0]}"
+        delete_warmpool_k(pool, namespace)
+        time.sleep(2)
+        snap, _ = snapshot_node_images(image)
+        apply_warmpool(pool, image, 1, namespace, node_hostname=node)
+        pods, _ = wait_pool_pods_ready(namespace, pool, 1, timeout)
+        obs = collect_pod_obs(namespace, pool, image, snap, pods)
+        o = obs[0] if obs else None
+        results.append(
+            (label, node, o.ready_s if o else None, o.pull_result if o else None)
+        )
+        delete_warmpool_k(pool, namespace)
+
+    table = Table(title="Cache-hit vs miss (single pod, pinned node)", show_lines=True)
+    table.add_column("Case", style="cyan")
+    table.add_column("Node")
+    table.add_column("Pod ready", justify="right", style="green")
+    table.add_column("Pull result", justify="right")
+    for label, node, rs, pr in results:
+        table.add_row(label, node, fmt(rs * 1000) if rs is not None else "-", pr or "-")
+    console.print(table)
+
+
+@app.command()
+def image_bench(
+    scenario: str = typer.Option(
+        "all", "--scenario", "-s", help="all | cold | spread | prewarm | hitmiss"
+    ),
+    image: str = typer.Option(DEFAULT_SWEBENCH_IMAGE, "--image", "-i", help="Large image to test."),
+    replicas: int = typer.Option(6, "--replicas", "-r", help="Replicas for cold/spread."),
+    namespace: str = typer.Option(DEFAULT_NAMESPACE, "--namespace", "-n", help="K8s namespace."),
+    gateway_url: str = typer.Option(DEFAULT_GATEWAY, "--gateway", "-g", help="Gateway URL."),
+    timeout: float = typer.Option(900.0, "--timeout", help="Max wait seconds per pool."),
+    port_forward: bool = typer.Option(
+        True, "--port-forward/--no-port-forward", help="Auto kubectl port-forward (prewarm only)."
+    ),
+) -> None:
+    """Benchmark image pull speed, startup speed, and cache-hit rate for large images.
+
+    Examples:
+        uv run python examples/python/bench_gateway.py image-bench -s cold
+        uv run python examples/python/bench_gateway.py image-bench -s spread -r 8
+        uv run python examples/python/bench_gateway.py image-bench   # runs all four
+    """
+    if not shutil.which("kubectl"):
+        raise typer.BadParameter("kubectl is required for image-bench")
+
+    console.rule(f"[bold green]Image Benchmark  (image={image})")
+    console.print(f"  scenario=[cyan]{scenario}[/cyan]  namespace={namespace}\n")
+
+    run_all = scenario == "all"
+    if run_all or scenario == "cold":
+        _scenario_cold(image, replicas, namespace, timeout)
+    if run_all or scenario == "spread":
+        _scenario_spread(image, replicas, namespace, timeout, [0.125, 0.25, 0.5, 1.0])
+    if run_all or scenario == "prewarm":
+        if port_forward:
+            ensure_port_forward(gateway_url, namespace)
+        _scenario_prewarm(image, namespace, gateway_url, timeout, [2, 5, 12])
+    if run_all or scenario == "hitmiss":
+        _scenario_hitmiss(image, namespace, timeout)
+
+    console.rule("[bold green]Image Benchmark complete")
 
 
 # =========================================================================

--- a/pkg/controller/image_pull_observer.go
+++ b/pkg/controller/image_pull_observer.go
@@ -82,9 +82,42 @@ func (o *ImagePullObserver) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
+	// Only record the pool's primary (user) container image. The event's
+	// fieldPath names the container; skip the injected sidecar and the init
+	// containers (executor-agent copy, tools) so cache-hit rate and pull
+	// duration reflect the user image rather than the small infra images.
+	container := containerFromFieldPath(ev.InvolvedObject.FieldPath)
+	if container == "" || container != primaryContainerName(pod) {
+		return ctrl.Result{}, nil
+	}
+
 	result, dur := parsePulledMessage(ev.Message)
 	o.Metrics.RecordImagePull(poolName, result, dur)
 	return ctrl.Result{}, nil
+}
+
+// primaryContainerName returns the pool's user container: the first container
+// that is not the operator-injected sidecar. Mirrors the WarmPool controller's
+// "first non-sidecar container" convention.
+func primaryContainerName(pod *corev1.Pod) string {
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name != "sidecar" {
+			return pod.Spec.Containers[i].Name
+		}
+	}
+	return ""
+}
+
+// containerFromFieldPath extracts the container name from a kubelet event
+// fieldPath such as "spec.containers{executor}". It returns "" for init
+// containers ("spec.initContainers{...}") and any other shape, so only the
+// pod's regular containers are considered.
+func containerFromFieldPath(fp string) string {
+	const prefix = "spec.containers{"
+	if !strings.HasPrefix(fp, prefix) || !strings.HasSuffix(fp, "}") {
+		return ""
+	}
+	return fp[len(prefix) : len(fp)-1]
 }
 
 // parsePulledMessage classifies a kubelet "Pulled" event message.

--- a/pkg/controller/image_pull_observer.go
+++ b/pkg/controller/image_pull_observer.go
@@ -1,0 +1,122 @@
+package controller
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/Lincyaw/agent-env/pkg/interfaces"
+	"github.com/Lincyaw/agent-env/pkg/labels"
+)
+
+// ImagePullObserver watches kubelet "Pulled" Events on warm-pool pods and
+// records image pull duration and cache hit/miss. Unlike pod container-start
+// timing, the kubelet event distinguishes "already present on machine" (cache
+// hit) from "Successfully pulled image ... in <dur>" (cache miss), giving an
+// accurate cache-hit rate and the true pull cost of large images.
+//
+// The operator's manager cache is configured (in cmd/operator) with a field
+// selector reason=Pulled so only image-pull events are watched.
+type ImagePullObserver struct {
+	client.Client
+	Metrics interfaces.MetricsCollector
+
+	// recorded deduplicates events by "namespace/name". kubelet aggregates
+	// repeated identical pulls into a single event whose count is bumped via
+	// Update; we record each event once. Entries are pruned when the event is
+	// garbage-collected by the apiserver (delivered as a delete → NotFound).
+	recorded sync.Map
+}
+
+// +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch
+
+// pulledDurationRe extracts the pull duration from a kubelet "Pulled" message,
+// e.g. `Successfully pulled image "x" in 1m2.345s (1m2.345s including waiting).
+// Image size: 12345 bytes.` — capturing the first Go-style duration token.
+var pulledDurationRe = regexp.MustCompile(`pulled image .* in ([0-9hmsµun.]+)`)
+
+// Reconcile processes a single kubelet "Pulled" event.
+func (o *ImagePullObserver) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	if o.Metrics == nil {
+		return ctrl.Result{}, nil
+	}
+
+	ev := &corev1.Event{}
+	if err := o.Get(ctx, req.NamespacedName, ev); err != nil {
+		if errors.IsNotFound(err) {
+			// Event was GC'd; drop its dedup entry to bound memory.
+			o.recorded.Delete(req.NamespacedName.String())
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	if ev.Reason != "Pulled" || ev.InvolvedObject.Kind != "Pod" {
+		return ctrl.Result{}, nil
+	}
+
+	if _, loaded := o.recorded.LoadOrStore(req.NamespacedName.String(), struct{}{}); loaded {
+		return ctrl.Result{}, nil
+	}
+
+	// Resolve the owning pool via the pod's label. The pod may already be gone
+	// (events can outlive pods); in that case we cannot attribute the pull.
+	pod := &corev1.Pod{}
+	if err := o.Get(ctx, client.ObjectKey{
+		Namespace: ev.InvolvedObject.Namespace,
+		Name:      ev.InvolvedObject.Name,
+	}, pod); err != nil {
+		return ctrl.Result{}, nil
+	}
+	poolName := pod.Labels[labels.PoolLabelKey]
+	if poolName == "" {
+		return ctrl.Result{}, nil
+	}
+
+	result, dur := parsePulledMessage(ev.Message)
+	o.Metrics.RecordImagePull(poolName, result, dur)
+	return ctrl.Result{}, nil
+}
+
+// parsePulledMessage classifies a kubelet "Pulled" event message.
+//
+//	"Container image \"x\" already present on machine"        -> ("hit", 0)
+//	"Successfully pulled image \"x\" in 1m2.3s (...)"          -> ("miss", 1m2.3s)
+//
+// Unparseable miss messages still count as a miss with zero duration so the
+// cache-hit rate stays accurate even if the duration format changes.
+func parsePulledMessage(msg string) (string, time.Duration) {
+	if strings.Contains(msg, "already present on machine") {
+		return "hit", 0
+	}
+	if m := pulledDurationRe.FindStringSubmatch(msg); len(m) == 2 {
+		if d, err := time.ParseDuration(m[1]); err == nil {
+			return "miss", d
+		}
+	}
+	return "miss", 0
+}
+
+// SetupWithManager registers the observer to watch Pulled events for pods.
+func (o *ImagePullObserver) SetupWithManager(mgr ctrl.Manager) error {
+	pred := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		ev, ok := obj.(*corev1.Event)
+		return ok && ev.Reason == "Pulled" && ev.InvolvedObject.Kind == "Pod"
+	})
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("image-pull-observer").
+		For(&corev1.Event{}, builder.WithPredicates(pred)).
+		Complete(o)
+}
+
+// Name returns the controller name for logging.
+func (o *ImagePullObserver) Name() string { return "ImagePullObserver" }

--- a/pkg/interfaces/metrics.go
+++ b/pkg/interfaces/metrics.go
@@ -40,6 +40,13 @@ type MetricsCollector interface {
 	// (ImagePullBackOff, ErrImagePull, PullQPSExceeded).
 	IncrementImagePullError(poolName, reason string)
 
+	// RecordImagePull records a container image pull observed from a kubelet
+	// "Pulled" event. result is "hit" (image already present on the node) or
+	// "miss" (image pulled from the registry); duration is the pull time
+	// (0 for hits). Use the per-result _count for cache-hit rate and the
+	// result="miss" histogram for the pull speed of large images.
+	RecordImagePull(poolName, result string, duration time.Duration)
+
 	// IncrementPodDelete increments pod deletion counter by pool and reason
 	// (scale_down, sandbox_cleanup).
 	IncrementPodDelete(poolName, reason string)
@@ -123,7 +130,9 @@ func (n *NoOpMetricsCollector) RecordAllPodsReady(poolName string, duration time
 func (n *NoOpMetricsCollector) RecordContainerStartDuration(poolName, containerName string, duration time.Duration) {
 }
 func (n *NoOpMetricsCollector) IncrementImagePullError(poolName, reason string) {}
-func (n *NoOpMetricsCollector) IncrementPodDelete(poolName, reason string)      {}
+func (n *NoOpMetricsCollector) RecordImagePull(poolName, result string, duration time.Duration) {
+}
+func (n *NoOpMetricsCollector) IncrementPodDelete(poolName, reason string) {}
 func (n *NoOpMetricsCollector) RecordSessionAllocationDuration(poolName string, duration time.Duration) {
 }
 func (n *NoOpMetricsCollector) SetActiveSessions(count int64) {}

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -19,6 +19,7 @@ type PrometheusCollector struct {
 	allPodsReadyDuration   *prometheus.HistogramVec
 	containerStartDuration *prometheus.HistogramVec
 	imagePullErrors        *prometheus.CounterVec
+	imagePullDuration      *prometheus.HistogramVec
 	podDeleteTotal         *prometheus.CounterVec
 
 	// Session allocation
@@ -121,6 +122,18 @@ func NewPrometheusCollector() interfaces.MetricsCollector {
 				Help: "Image pull failures by pool and reason (ImagePullBackOff, ErrImagePull, PullQPSExceeded).",
 			},
 			[]string{"pool", "reason"},
+		),
+
+		imagePullDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name: "arl_warmpool_image_pull_seconds",
+				Help: "Container image pull time from kubelet Pulled events, by pool and result " +
+					"(hit=already present on node, miss=pulled from registry). " +
+					"Per-result _count gives cache hit rate; filter result=\"miss\" for large-image pull speed.",
+				// Wide buckets: large SWE-bench-style images can take minutes on a cold node.
+				Buckets: []float64{0.1, 0.5, 1, 2, 5, 10, 20, 30, 60, 120, 300, 600},
+			},
+			[]string{"pool", "result"},
 		),
 
 		podDeleteTotal: prometheus.NewCounterVec(
@@ -287,6 +300,7 @@ func NewPrometheusCollector() interfaces.MetricsCollector {
 		c.allPodsReadyDuration,
 		c.containerStartDuration,
 		c.imagePullErrors,
+		c.imagePullDuration,
 		c.podDeleteTotal,
 		c.sessionAllocationDuration,
 		c.activeSessions,
@@ -323,6 +337,8 @@ func (c *PrometheusCollector) DeletePoolMetrics(poolName string) {
 	c.poolUtilization.DeleteLabelValues(poolName, "ready")
 	c.poolUtilization.DeleteLabelValues(poolName, "allocated")
 	c.pendingPods.DeleteLabelValues(poolName)
+	c.imagePullDuration.DeleteLabelValues(poolName, "hit")
+	c.imagePullDuration.DeleteLabelValues(poolName, "miss")
 }
 
 func (c *PrometheusCollector) RecordPodScheduleDuration(poolName string, duration time.Duration) {
@@ -347,6 +363,10 @@ func (c *PrometheusCollector) RecordContainerStartDuration(poolName, containerNa
 
 func (c *PrometheusCollector) IncrementImagePullError(poolName, reason string) {
 	c.imagePullErrors.WithLabelValues(poolName, reason).Inc()
+}
+
+func (c *PrometheusCollector) RecordImagePull(poolName, result string, duration time.Duration) {
+	c.imagePullDuration.WithLabelValues(poolName, result).Observe(duration.Seconds())
 }
 
 func (c *PrometheusCollector) IncrementPodDelete(poolName, reason string) {


### PR DESCRIPTION
## Summary
Adds observability for **image pull cost and cache locality** (the dominant factor in cold-start latency for large images) plus a client-side benchmark.

- **Operator metric** `arl_warmpool_image_pull_seconds{pool,result=hit|miss}` — `ImagePullObserver` watches kubelet `Pulled` events, parses cache hit (`already present`) vs miss (`Successfully pulled … in <dur>`), and records duration. Filtered to the pool's **primary (user) container** so infra images (sidecar/executor-agent) don't skew it. Event cache scoped to `reason=Pulled` (bounded memory).
- **RBAC**: `events get/list/watch`.
- **Grafana**: *Image Pull Cache Hit Rate* + *Pull Duration (miss p50/p95/avg)* panels.
- **`examples/bench_gateway.py image-bench`** — four scenarios: cold pull, spreadFactor sweep, prewarm-vs-cold-start-tail, hit-vs-miss. Cache-hit computed from a `node.status.images` pre-snapshot.

## Measured (Django SWE-bench eval image, ~1.2 GiB compressed)
- Cold pull **~69s**, pod-ready **~78s**, ~18 MiB/s.
- Cache-hit (warm node) **2.0s** vs cold node **65.0s** → locality saves ~63s.
- Prewarm: within warm buffer sub-second; beyond buffer p95 climbs to ~21s.
- Finding: once a node caches the image, K8s built-in ImageLocality packs pods there, masking the operator's `spreadFactor` (it mainly governs first placement of a never-seen image).

## Validation
`go build ./...`, `go vet`, `go mod tidy`, `make arch-check`, `helm template` all pass. Verified live on a VKE cluster (metric populated, panels render).